### PR TITLE
Fixes #13: Prevent failure when code directory already exists.

### DIFF
--- a/src/fileUtil.ts
+++ b/src/fileUtil.ts
@@ -67,6 +67,10 @@ export class FileUtil {
             ignoreList.push("__MACOSX");
         }
 
+        if (await FileUtil.directoryExists(destinationDir.directory, destinationDir.path)) {
+            await Filesystem.rmdir({ directory: destinationDir.directory, path: destinationDir.path, recursive: true });
+        }
+
         return FileUtil.copy(sourceDir, destinationDir);
     }
 


### PR DESCRIPTION
I'm not sure if there are any side-effects of this. I looked through the code to see what calls this method, and it *seems* like it is narrowly used, and ... I also don't know what the alternative is here aside from writing a recursive copy function?