### PR TITLE
Capacitor plugin dependencies should be peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "MAPIACOMPANY",
   "license": "MIT",
   "devDependencies": {
+    "@capacitor/cli": "^3.0.0-beta.3",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
@@ -61,15 +62,15 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
+    "code-push": "^4.0.2"
+  },
+  "peerDependencies": {
     "@capacitor-community/http": "^1.0.0-alpha.0",
-    "@capacitor/cli": "^3.0.0-beta.3",
     "@capacitor/core": "^3.0.0-beta.3",
     "@capacitor/device": "^0.5.3",
     "@capacitor/dialog": "^0.4.3",
-    "@capacitor/filesystem": "^0.4.0",
-    "code-push": "^4.0.2"
+    "@capacitor/filesystem": "^0.4.0"
   },
-  "peerDependencies": {},
   "capacitor": {
     "android": {
       "src": "android"


### PR DESCRIPTION
Fixing the dependency versions in package.json dependencies can cause NPM resolution hard-wiring issues. This fixes the problem using peer dependencies.