### PR TITLE
README.md: correct npm install line for peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Capacitor v3 is still in beta. Until major update, this plugin can be unstable.
 Once you've followed the general-purpose ["getting started"](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/) instructions for setting up your CodePush account, you can start CodePush-ifying your Capacitor app by running the following command from within your app's root directory:
 
 ```shell
-npm i @capacitor-community/http @capacitor/deivce @capacitor/dialog @capacitor/filesystem -D
+npm i @capacitor-community/http@next @capacitor/device @capacitor/dialog @capacitor/filesystem -D
 npm i https://github.com/mapiacompany/capacitor-codepush -D
 npx cap sync
 ```


### PR DESCRIPTION
The npm install line in the README currently doesn't work.

Version 0.3.x of @capacitor-community/http is installed by it, which isn't peer-compatible with the intended version here.

Also, device is spelled wrong. :)

I correct those issues in this PR.

Thanks for the library!